### PR TITLE
Lower prerequisites to Java 8 and Maven 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # jacoco-aggregator-maven-plugin
 
-This simple Apache Maven Mojo will help you generate aggregated Jacoco from muti modules projects.
+## Prerequisites
+
+- Java 8 or newer
+- Maven 3 or newer
+
+## Usage
+
+This simple Apache Maven Mojo will help you generate aggregated Jacoco from multi modules projects.
 
 This will prevent you creating extra Maven module as a workaround proposed here: https://www.baeldung.com/maven-jacoco-multi-module-project
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.release>17</maven.compiler.release>
-    <maven.version>3.9.9</maven.version>
+    <maven.compiler.release>8</maven.compiler.release><!-- same level as jacoco-maven-plugin -->
+    <maven.version>3.0</maven.version><!-- same level as jacoco-maven-plugin -->
     <jacoco.version>0.8.13</jacoco.version>
     <njord.autoPublish>true</njord.autoPublish>
     <drop>false</drop>


### PR DESCRIPTION
This is in line with jacoco-maven-plugin 0.8.13
This closes #30